### PR TITLE
Fix to azure/template.json

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -120,7 +120,7 @@
                         "value": "[parameters('customHostName')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[if(greater(length(parameters('customHostname')), 0), reference(resourceId(parameters('appServicePlanResourceGroup'), 'Microsoft.Web/certificates', parameters('keyVaultCertificateName')), '2016-03-01').Thumbprint, '')]"
+                        "value": "[if(greater(length(parameters('customHostname')), 0), reference(resourceId(parameters('sharedResourceGroup'), 'Microsoft.Web/certificates', parameters('keyVaultCertificateName')), '2016-03-01').Thumbprint, '')]"
                     }
                 }
             }


### PR DESCRIPTION
I was referencing parameter appServicePlanResourceGroup in the certificateThumprint parameter which was undefined in my master template parameters (it was only to be used as a parameter in the linked template deployment). This was causing a deployment error code InvalidTemplate with the error message "Deployment template validation failed: 'The template parameter 'appServicePlanResourceGroup' is not found."

The fix is to change the parameter appServicePlanResourceGroup to sharedResourceGroup.