### PR TITLE
Updated YAML build definition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ steps:
   displayName: Test
   inputs:
     command: test
-    projects: 'src/**/*.Web.UnitTests.csproj'
+    projects: 'src/**/*.UnitTests.csproj'
     arguments: '--configuration $(buildConfiguration) --no-build'
 
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
Updated the YAML build definition Test step to include projects that end *.UnitTests.csproj instead of specifically *.Web.UnitTests.csproj. This is to ensure that the tests in the assembly containing .Application.UnitTests.csproj are also included in this build step.