### PR TITLE
Added the redis cache connection string

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -47,6 +47,9 @@
         },
         "keyVaultCertificateName": {
            "type": "string"
+        },
+        "loggingRedisConnectionString": {
+           "type": "string"
         }
     },
     "variables": {
@@ -113,6 +116,15 @@
                             {
                                 "name": "ASPNETCORE_ENVIRONMENT",
                                 "value": "[toUpper(parameters('environmentName'))]"
+                            }
+                        ]
+                    },
+                    "appServiceConnectionStrings": {
+                        "value": [
+                            {
+                                "name": "Redis",
+                                "connectionString": "[parameters('loggingRedisConnectionString')]",
+                                "type": "Custom"
                             }
                         ]
                     },


### PR DESCRIPTION
This PR is to add in support for logging to Kibana. The ARM template has been updated to include an appServiceConnectionStrings block and redis connection string using the loggingRedisConnectionString parameter. 